### PR TITLE
función + test de isMarkdown

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -4,9 +4,11 @@ const path = require('path');
 const pathExists = (path) => fs.existsSync(path);
 const isAbsolutePath = (inputPath) => path.isAbsolute(inputPath);
 const toAbsolute = (inputPath) => path.resolve(inputPath);
+const isMarkdown = (inputPath) => path.extname(inputPath) === '.md';
 
 module.exports = {
   pathExists,
   isAbsolutePath,
   toAbsolute,
+  isMarkdown,
 };

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -1,4 +1,6 @@
-const { pathExists, isAbsolutePath, toAbsolute } = require('../src/api');
+const {
+  pathExists, isAbsolutePath, toAbsolute, isMarkdown,
+} = require('../src/api');
 
 describe('pathExists test', () => {
   const existPath = 'C:\\Users\\Dell\\Documents\\GitHub\\DEV001-md-links\\folder-test';
@@ -30,5 +32,17 @@ describe('toAbsolute test', () => {
 
   it('debe retornar una ruta absoluta', () => {
     expect(toAbsolute(relativePath)).toBe(absolutePath);
+  });
+});
+
+describe('isMarkdown test', () => {
+  const markdownFile = 'C:\\Users\\Dell\\Documents\\GitHub\\DEV001-md-links\\folder-test\\file-md.md';
+  const txtFile = 'C:\\Users\\Dell\\Documents\\GitHub\\DEV001-md-links\\folder-test\\file-txt.txt';
+
+  it('debe retornar true si la ruta es un archivo markdown', () => {
+    expect(isMarkdown(markdownFile)).toBe(true);
+  });
+  it('debe retornar false si la ruta no es un archivo markdown', () => {
+    expect(isMarkdown(txtFile)).toBe(false);
   });
 });


### PR DESCRIPTION
Se creó la función isMarkdown para reconocer si un archivo es .md, de igual forma, se realizaron los test de la respectiva función.